### PR TITLE
Merge UserIdTest into main

### DIFF
--- a/project/.idea/vcs.xml
+++ b/project/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/project/app/build.gradle.kts
+++ b/project/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.application")
+    id("com.google.gms.google-services")
 }
 
 android {
@@ -40,5 +41,9 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     implementation("com.journeyapps:zxing-android-embedded:4.3.0")
     implementation("com.google.zxing:core:3.4.1")
+
     implementation(platform("com.google.firebase:firebase-bom:32.7.2"))
+    implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-auth")
+    implementation("com.google.firebase:firebase-firestore")
 }

--- a/project/app/google-services.json
+++ b/project/app/google-services.json
@@ -1,0 +1,67 @@
+{
+  "project_info": {
+    "project_number": "976207794099",
+    "project_id": "cmput301-rallyup",
+    "storage_bucket": "cmput301-rallyup.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:976207794099:android:2ab0c14eac87151cf705c6",
+        "android_client_info": {
+          "package_name": "com.example.qrgeneration"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAr75I-ex8-p4Xc9fc_IV8eBcK1kyqEINI"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:976207794099:android:e4a3c38b74faf60ef705c6",
+        "android_client_info": {
+          "package_name": "com.example.rallyup"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAr75I-ex8-p4Xc9fc_IV8eBcK1kyqEINI"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:976207794099:android:0447a4523202f231f705c6",
+        "android_client_info": {
+          "package_name": "com.ualberta.rally_up_experimental"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAr75I-ex8-p4Xc9fc_IV8eBcK1kyqEINI"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/project/app/src/main/AndroidManifest.xml
+++ b/project/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".RallyUpApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/project/app/src/main/java/com/example/rallyup/FirestoreController.java
+++ b/project/app/src/main/java/com/example/rallyup/FirestoreController.java
@@ -3,7 +3,10 @@ package com.example.rallyup;
 import android.util.Log;
 
 import com.example.rallyup.firestoreObjects.Event;
+import com.example.rallyup.firestoreObjects.User;
+import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 
@@ -38,9 +41,9 @@ public class FirestoreController {
     }
 
     // Create a new user in the Firestore and return its userID
-    public String createUserID() {
-        // TODO
-        return "hulaballoo";
+    public void createUserID(final OnCompleteListener<DocumentReference> onCompleteListener) {
+        usersRef.add(new User())
+                .addOnCompleteListener(onCompleteListener);
     }
 
     public void examplePrintAllAttendance() {

--- a/project/app/src/main/java/com/example/rallyup/FirestoreController.java
+++ b/project/app/src/main/java/com/example/rallyup/FirestoreController.java
@@ -1,0 +1,63 @@
+package com.example.rallyup;
+
+import android.util.Log;
+
+import com.example.rallyup.firestoreObjects.Event;
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.HashMap;
+
+public class FirestoreController {
+    private static final FirestoreController instance = new FirestoreController();
+
+    private final FirebaseFirestore dbRef;
+    private final CollectionReference usersRef;
+    private final CollectionReference eventsRef;
+    private final CollectionReference eventAttendanceRef;
+
+    public FirestoreController() {
+        dbRef = FirebaseFirestore.getInstance();
+        usersRef = dbRef.collection("users");
+        eventsRef = dbRef.collection("events");
+        eventAttendanceRef = dbRef.collection("eventAttendance");
+    }
+
+    public static FirestoreController getInstance() {
+        return instance;
+    }
+
+    public void addEvent(Event event) {
+        // Add the event to the Firestore collection
+        HashMap<String, String> data = new HashMap<>();
+        data.put("title", event.getEventName());
+        data.put("location", event.getEventLocation());
+        data.put("description", event.getEventDescription());
+        eventsRef.document("TEST EVENT NOT ALL PARAMETERS").set(data);
+    }
+
+    // Create a new user in the Firestore and return its userID
+    public String createUserID() {
+        // TODO
+        return "hulaballoo";
+    }
+
+    public void examplePrintAllAttendance() {
+        dbRef.collection("eventAttendance").get().addOnCompleteListener(task -> {
+            if (task.isSuccessful()) {
+                for (DocumentSnapshot document : task.getResult()) {
+                    // Access document data
+                    String eventID = document.getString("eventID");
+                    String userID = document.getString("userID");
+                    Boolean verified = document.getBoolean("attendeeVerified");
+                    Log.d("FirestoreController", eventID + ' ' + userID);
+                }
+            } else {
+                Log.d("FirestoreController", "Error getting documents: " + task.getException());
+            }
+        });
+    }
+}
+
+

--- a/project/app/src/main/java/com/example/rallyup/LocalStorageController.java
+++ b/project/app/src/main/java/com/example/rallyup/LocalStorageController.java
@@ -1,0 +1,44 @@
+package com.example.rallyup;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class LocalStorageController {
+    private static final LocalStorageController instance = new LocalStorageController();
+
+    private static final String PREF_NAME = "RallyUpPreferences";
+    private static final String KEY_USER_ID = "userID";
+    public static LocalStorageController getInstance() {
+        return instance;
+    }
+
+    // Method to retrieve userID from SharedPreferences
+    public static String getUserID(Context context) {
+        if (existsUserID(context)) {
+            // User has used the app before: return existing ID
+            SharedPreferences sharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+            return sharedPreferences.getString(KEY_USER_ID, null);
+        } else {
+            // New user: create new ID for them
+            return createNewUserID(context);
+        }
+    }
+
+    // Method to create userID and save it to SharedPreferences
+    public static String createNewUserID(Context context) {
+        FirestoreController fc = FirestoreController.getInstance();
+        String newID = fc.createUserID();
+
+        SharedPreferences sharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putString(KEY_USER_ID, newID);
+        editor.apply();
+        return newID;
+    }
+
+    // Method to check if userID exists in SharedPreferences
+    public static boolean existsUserID(Context context) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        return sharedPreferences.contains(KEY_USER_ID);
+    }
+}

--- a/project/app/src/main/java/com/example/rallyup/LocalStorageController.java
+++ b/project/app/src/main/java/com/example/rallyup/LocalStorageController.java
@@ -8,36 +8,44 @@ public class LocalStorageController {
 
     private static final String PREF_NAME = "RallyUpPreferences";
     private static final String KEY_USER_ID = "userID";
+    private boolean idInitialized = false;
+
     public static LocalStorageController getInstance() {
         return instance;
     }
 
-    // Method to retrieve userID from SharedPreferences
-    public static String getUserID(Context context) {
+    public void initialization(Context context) {
         if (existsUserID(context)) {
-            // User has used the app before: return existing ID
-            SharedPreferences sharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
-            return sharedPreferences.getString(KEY_USER_ID, null);
+            idInitialized = true;
         } else {
-            // New user: create new ID for them
-            return createNewUserID(context);
+            createNewUserID(context);
         }
     }
 
+    // Method to retrieve userID from SharedPreferences
+    public String getUserID(Context context) {
+        assert idInitialized;
+        SharedPreferences sharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+        return sharedPreferences.getString(KEY_USER_ID, null);
+    }
+
     // Method to create userID and save it to SharedPreferences
-    public static String createNewUserID(Context context) {
+    public void createNewUserID(Context context) {
         FirestoreController fc = FirestoreController.getInstance();
         String newID = fc.createUserID();
 
-        SharedPreferences sharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
-        SharedPreferences.Editor editor = sharedPreferences.edit();
-        editor.putString(KEY_USER_ID, newID);
-        editor.apply();
-        return newID;
+        {
+            // Firestore ID generation completed
+            SharedPreferences sharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
+            SharedPreferences.Editor editor = sharedPreferences.edit();
+            editor.putString(KEY_USER_ID, newID);
+            editor.apply();
+            idInitialized = true;
+        }
     }
 
     // Method to check if userID exists in SharedPreferences
-    public static boolean existsUserID(Context context) {
+    public boolean existsUserID(Context context) {
         SharedPreferences sharedPreferences = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
         return sharedPreferences.contains(KEY_USER_ID);
     }

--- a/project/app/src/main/java/com/example/rallyup/MainActivity.java
+++ b/project/app/src/main/java/com/example/rallyup/MainActivity.java
@@ -4,6 +4,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 

--- a/project/app/src/main/java/com/example/rallyup/RallyUpApplication.java
+++ b/project/app/src/main/java/com/example/rallyup/RallyUpApplication.java
@@ -1,0 +1,19 @@
+package com.example.rallyup;
+
+import android.app.Application;
+
+public class RallyUpApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        MySingletonInitializer();
+        LocalStorageController lc = LocalStorageController.getInstance();
+        lc.initialization(this);
+    }
+    public static void MySingletonInitializer() {
+        // This static block ensures that singletons are initialized in the desired order
+        FirestoreController.getInstance();
+        LocalStorageController.getInstance();
+    }
+}
+

--- a/project/app/src/main/java/com/example/rallyup/firestoreObjects/Event.java
+++ b/project/app/src/main/java/com/example/rallyup/firestoreObjects/Event.java
@@ -1,0 +1,78 @@
+package com.example.rallyup.firestoreObjects;
+
+/**
+ * Represents an event with a name, location, and description.
+ */
+public class Event {
+    private String eventName;
+    private String eventLocation;
+    private String eventDescription;
+
+    /**
+     * Constructs a new Event object with the given name, location, and description.
+     *
+     * @param eventName        The name of the event.
+     * @param eventLocation    The location of the event.
+     * @param eventDescription The description of the event.
+     */
+    public Event(String eventName, String eventLocation, String eventDescription) {
+        this.eventName = eventName;
+        this.eventLocation = eventLocation;
+        this.eventDescription = eventDescription;
+    }
+
+    /**
+     * Gets the name of the event.
+     *
+     * @return The name of the event.
+     */
+    public String getEventName() {
+        return eventName;
+    }
+
+    /**
+     * Sets the name of the event.
+     *
+     * @param eventName The new name of the event.
+     */
+    public void setEventName(String eventName) {
+        this.eventName = eventName;
+    }
+
+    /**
+     * Gets the location of the event.
+     *
+     * @return The location of the event.
+     */
+    public String getEventLocation() {
+        return eventLocation;
+    }
+
+    /**
+     * Sets the location of the event.
+     *
+     * @param eventLocation The new location of the event.
+     */
+    public void setEventLocation(String eventLocation) {
+        this.eventLocation = eventLocation;
+    }
+
+    /**
+     * Gets the description of the event.
+     *
+     * @return The description of the event.
+     */
+    public String getEventDescription() {
+        return eventDescription;
+    }
+
+    /**
+     * Sets the description of the event.
+     *
+     * @param eventDescription The new description of the event.
+     */
+    public void setEventDescription(String eventDescription) {
+        this.eventDescription = eventDescription;
+    }
+}
+

--- a/project/app/src/main/java/com/example/rallyup/firestoreObjects/User.java
+++ b/project/app/src/main/java/com/example/rallyup/firestoreObjects/User.java
@@ -1,0 +1,23 @@
+package com.example.rallyup.firestoreObjects;
+
+public class User {
+    String email = "Sample email";
+
+    public User() {
+    }
+
+    // Constructor with email parameter
+    public User(String email) {
+        this.email = email;
+    }
+
+    // Getter for email
+    public String getEmail() {
+        return email;
+    }
+
+    // Setter for email
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/project/app/src/main/java/com/example/rallyup/qrGeneration/AddEvent.java
+++ b/project/app/src/main/java/com/example/rallyup/qrGeneration/AddEvent.java
@@ -23,7 +23,9 @@ import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.example.rallyup.FirestoreController;
 import com.example.rallyup.R;
+import com.example.rallyup.firestoreObjects.Event;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.MultiFormatWriter;
@@ -385,8 +387,11 @@ public class AddEvent extends AppCompatActivity {
             geoInput.setChecked(false);
             attendeeInfoInput.setChecked(false);
             newQRSelect.setChecked(false);
-            // send values to fb
 
+            // send values to fb
+            Event newEvent = new Event(eventName, eventLocation, eventDescription);
+            FirestoreController fc = FirestoreController.getInstance();
+            fc.addEvent(newEvent);
         }
     }
 }

--- a/project/app/src/main/java/com/example/rallyup/qrGeneration/MainActivity.java
+++ b/project/app/src/main/java/com/example/rallyup/qrGeneration/MainActivity.java
@@ -5,10 +5,12 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
 
+import com.example.rallyup.LocalStorageController;
 import com.example.rallyup.R;
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.MultiFormatWriter;
@@ -47,7 +49,8 @@ public class MainActivity extends AppCompatActivity {
             startActivity(a);
         });
 
-
+        LocalStorageController lc = LocalStorageController.getInstance();
+        Log.d("MainActivity", lc.getUserID(this));
     }
 
     private void generateQR() {


### PR DESCRIPTION
Adds FireStoreController and LocalStorageController, allowing for online data management (events) and generating userIDs with no login. Also created RallyUpApplication for any initializations that need to be done at the beginning of runtime.

Does lightly edit the AndroidManifest and the MainActivity, so there may be light merge conflicts in the future.